### PR TITLE
Change FAQ URL 

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -1,7 +1,7 @@
 show_reach: true
 copyright_agency: Open Government Products
 contact_us: /about-us/contact-us/
-faq: https://console.apac.sabio.cloud/FAQ/index.aspx?p=64759355
+faq: https://ask.gov.sg/mlaw
 feedback: https://eservices.mlaw.gov.sg/enquiry/
 privacy: /privacy/
 terms_of_use: /terms-of-use/

--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ sections:
   - hero:
       title: Ministry of Law Singapore
       subtitle: Advancing access to justice, the rule of law, the economy and society
-        through policy, law and services
+        through policy, law and services.
       background: /images/Hero-Banner-Minlaw.jpg
       button: Learn More
       url: /about-us/ourvision-mission-corevalues/

--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ sections:
   - hero:
       title: Ministry of Law Singapore
       subtitle: Advancing access to justice, the rule of law, the economy and society
-        through policy, law and services.
+        through policy, law and services
       background: /images/Hero-Banner-Minlaw.jpg
       button: Learn More
       url: /about-us/ourvision-mission-corevalues/


### PR DESCRIPTION
The link to the FAQ found in the footer has been changed to the AskGov's URL.